### PR TITLE
feat(schedule): Implement Combined Schedule View and Enhance Scheduling UI

### DIFF
--- a/src/app/components/schedule/CombinedScheduleView.tsx
+++ b/src/app/components/schedule/CombinedScheduleView.tsx
@@ -1,0 +1,159 @@
+
+'use client';
+
+import React from 'react';
+import type { ScheduleEntry, Appliance, Apartment } from '@/types';
+
+interface CombinedScheduleViewProps {
+  scheduleData: ScheduleEntry[]; // Should contain data for all relevant apartments
+  appliances: Appliance[];
+  apartments: Apartment[]; // List of apartments to display schedules for
+  // Props for specific day/week selection might be needed later
+}
+
+const daysOfWeek = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const timeSlots = Array.from({ length: 24 }, (_, i) => {
+  const hour = i.toString().padStart(2, '0');
+  return `${hour}:00`;
+});
+
+// Updated color scheme for apartments
+const apartmentColors: { [key: string]: string } = {
+  stensvoll: '#A0D2DB', // Light Teal/Greenish Blue
+  nowak: '#C3AED6',     // Light Purple/Lavender
+  default: '#E0E0E0',    // Default light gray for any other/unassigned
+  conflict: '#F2A63A',  // Warm Orange for conflicts (as per style guide accent color)
+};
+
+const CombinedScheduleView: React.FC<CombinedScheduleViewProps> = ({
+  scheduleData,
+  appliances,
+  apartments,
+}) => {
+  const headerCellStyle = {
+    border: '1px solid #D1D5DB',
+    padding: '0.5rem',
+    minHeight: '40px',
+    fontSize: '0.75rem',
+    textAlign: 'center' as 'center',
+    backgroundColor: '#F0F4F8',
+    fontWeight: 'bold',
+    color: '#2C3E50',
+  };
+
+  const timeSlotCellStyle = {
+    border: '1px solid #D1D5DB',
+    padding: '0.25rem',
+    minHeight: '50px',
+    fontSize: '0.7rem',
+    textAlign: 'center' as 'center',
+    position: 'relative' as 'relative',
+    overflow: 'hidden',
+  };
+
+  const entryStyle = (apartmentId: string) => ({
+    fontSize: '0.65rem',
+    padding: '2px',
+    margin: '1px 0',
+    borderRadius: '3px',
+    backgroundColor: apartmentColors[apartmentId] || apartmentColors.default,
+    color: '#333', // Darker text for better readability on light pastel backgrounds
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as 'nowrap',
+  });
+
+  return (
+    <div style={{ fontFamily: 'Inter, sans-serif', backgroundColor: '#FFFFFF', padding: '1rem' }}>
+      <h2 style={{ color: '#5D9CEC', marginBottom: '1rem' }}>Combined Weekly Schedule</h2>
+      <div 
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `60px repeat(${daysOfWeek.length}, 1fr)`,
+          gridTemplateRows: `auto repeat(${timeSlots.length}, auto)`,
+          border: '1px solid #D1D5DB',
+          overflowX: 'auto',
+        }}
+      >
+        <div style={headerCellStyle}></div> {/* Empty top-left corner */}
+        {daysOfWeek.map(day => (
+          <div key={day} style={headerCellStyle}>{day}</div>
+        ))}
+
+        {timeSlots.map(time => (
+          <React.Fragment key={time}>
+            <div style={headerCellStyle}>{time}</div>
+            {daysOfWeek.map(day => {
+              // Find entries for this specific day and time for all apartments
+              const entriesForSlot = scheduleData.filter(
+                e => e.day === day && e.time === time
+              );
+
+              return (
+                <div 
+                  key={`${day}-${time}`}
+                  style={timeSlotCellStyle}
+                  aria-label={`Slot for ${day} at ${time}`}
+                >
+                  {entriesForSlot.length > 0 ? (
+                    entriesForSlot.map(entry => {
+                      const appliance = appliances.find(app => app.id === entry.applianceId);
+                      const apartment = apartments.find(apt => apt.id === entry.apartmentId);
+                      return (
+                        <div 
+                          key={`${entry.apartmentId}-${entry.applianceId}`}
+                          style={entryStyle(entry.apartmentId)}
+                          title={`${appliance?.name} for ${apartment?.name || entry.apartmentId}`}
+                        >
+                          {appliance?.icon} {appliance?.name?.substring(0,10)}{appliance && appliance.name.length > 10 ? '...' : ''}
+                        </div>
+                      );
+                    })
+                  ) : (
+                    <span style={{ color: '#A0A0A0', fontSize:'0.6rem' }}>Empty</span>
+                  )}
+                </div>
+              );
+            })}
+          </React.Fragment>
+        ))}
+      </div>
+      {/* Color Legend */}
+      <div style={{ marginTop: '1rem', padding: '0.5rem', backgroundColor: '#F0F4F8', borderRadius: '4px' }}>
+        <h4 style={{ margin: '0 0 0.5rem 0', color: '#2C3E50' }}>Legend:</h4>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+          {apartments.map(apt => (
+            <div key={apt.id} style={{ display: 'flex', alignItems: 'center' }}>
+              <span 
+                style={{
+                  display: 'inline-block',
+                  width: '1rem',
+                  height: '1rem',
+                  backgroundColor: apartmentColors[apt.id] || apartmentColors.default,
+                  marginRight: '0.5rem',
+                  border: '1px solid #CCC'
+                }}
+              ></span>
+              <span style={{ fontSize: '0.8rem', color: '#333' }}>{apt.name}</span>
+            </div>
+          ))}
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <span 
+              style={{
+                display: 'inline-block',
+                width: '1rem',
+                height: '1rem',
+                backgroundColor: apartmentColors.conflict,
+                marginRight: '0.5rem',
+                border: '1px solid #CCC'
+              }}
+            ></span>
+            <span style={{ fontSize: '0.8rem', color: '#333' }}>Conflict</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CombinedScheduleView;

--- a/src/app/components/schedule/CombinedScheduleView.tsx
+++ b/src/app/components/schedule/CombinedScheduleView.tsx
@@ -89,11 +89,22 @@ const CombinedScheduleView: React.FC<CombinedScheduleViewProps> = ({
                 e => e.day === day && e.time === time
               );
 
+              const uniqueApartmentIdsInSlot = new Set(entriesForSlot.map(e => e.apartmentId));
+              const isConflictingSlot = uniqueApartmentIdsInSlot.size > 1;
+
+              const currentSlotStyle = {
+                ...timeSlotCellStyle,
+                ...(isConflictingSlot && { 
+                  backgroundColor: '#FFEFCF', // Light orange/yellowish for conflict indication
+                  // border: `2px solid ${apartmentColors.conflict}` // Alternative: border highlight
+                }),
+              };
+
               return (
                 <div 
                   key={`${day}-${time}`}
-                  style={timeSlotCellStyle}
-                  aria-label={`Slot for ${day} at ${time}`}
+                  style={currentSlotStyle}
+                  aria-label={`Slot for ${day} at ${time}${isConflictingSlot ? ', conflicting bookings' : ''}`}
                 >
                   {entriesForSlot.length > 0 ? (
                     entriesForSlot.map(entry => {

--- a/src/app/schedule/combined/page.tsx
+++ b/src/app/schedule/combined/page.tsx
@@ -1,0 +1,43 @@
+
+'use client';
+
+import React from 'react';
+import CombinedScheduleView from '@/app/components/schedule/CombinedScheduleView';
+import type { ScheduleEntry, Appliance, Apartment } from '@/types';
+
+// Mock data for demonstration
+const MOCK_APPLIANCES: Appliance[] = [
+  { id: 'car_charger', name: 'Car Charger', icon: '🔌' },
+  { id: 'oven', name: 'Oven', icon: '🍳' },
+  { id: 'washing_machine', name: 'Washing Machine', icon: '🧺' },
+  { id: 'dryer', name: 'Dryer', icon: '💨' },
+  { id: 'dishwasher', name: 'Dishwasher', icon: '🍽️' },
+];
+
+const MOCK_APARTMENTS: Apartment[] = [
+  { id: 'stensvoll', name: 'Stensvoll Household' },
+  { id: 'nowak', name: 'Nowak Household' },
+];
+
+const MOCK_SCHEDULE_DATA: ScheduleEntry[] = [
+  { day: 'Mon', time: '09:00', applianceId: 'washing_machine', userId: 'user1', apartmentId: 'stensvoll' },
+  { day: 'Mon', time: '10:00', applianceId: 'dryer', userId: 'user1', apartmentId: 'stensvoll' },
+  { day: 'Mon', time: '09:00', applianceId: 'oven', userId: 'user3', apartmentId: 'nowak' },
+  { day: 'Tue', time: '14:00', applianceId: 'car_charger', userId: 'user2', apartmentId: 'stensvoll' },
+  { day: 'Wed', time: '18:00', applianceId: 'dishwasher', userId: 'user4', apartmentId: 'nowak' },
+  { day: 'Wed', time: '18:00', applianceId: 'oven', userId: 'user1', apartmentId: 'stensvoll' }, // Example conflict
+];
+
+export default function CombinedSchedulePage() {
+  return (
+    <div style={{ padding: '20px', fontFamily: "'Inter', sans-serif" }}>
+      <h1 style={{ color: '#5D9CEC' }}>Combined Appliance Schedules</h1>
+      <p style={{ color: '#2C3E50' }}>View schedules for all apartments.</p>
+      <CombinedScheduleView 
+        scheduleData={MOCK_SCHEDULE_DATA}
+        appliances={MOCK_APPLIANCES}
+        apartments={MOCK_APARTMENTS}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
This pull request significantly advances the scheduling capabilities of the AmpShare application by introducing the Combined Schedule Display and integrating the individual scheduling components.

Key features and improvements include:

*   **Combined Schedule Display (`CombinedScheduleView.tsx`)**:
    *   A new view at `/schedule/combined` that displays a unified weekly schedule grid for all apartments.
    *   Implemented color-coding to visually distinguish entries from different apartments (e.g., Stensvoll - Light Teal, Nowak - Light Lavender).
    *   Added a legend to explain the color scheme, including a placeholder for future conflict highlighting.
    *   Includes basic conflict visualization: time slots where more than one apartment has a scheduled item are highlighted with a light orange background.

*   **Scheduling UI Integration (`/schedule` page)**:
    *   The main scheduling page (`/schedule`) now integrates `ApplianceSelector`, `ApartmentFilter`, and `ScheduleGrid` with shared state management.
    *   Users can select an appliance and an apartment, and then click on time slots in the `ScheduleGrid` to add or remove schedule entries.
    *   The `ScheduleGrid` dynamically displays appliance icons in the slots based on current selections and schedule data.
    *   Added `Appliance` and `ScheduleEntry` interfaces to `src/types.ts` to support this functionality.

*   **Underlying Component Enhancements**:
    *   `ScheduleGrid.tsx` now accepts and processes `scheduleData`, `selectedApartmentId`, an `onTimeSlotClick` handler, and `appliances` list.
    *   `TimeSlot.tsx` has been refactored to be controlled by its parent, receiving `scheduledApplianceDetails` and an `onClick` callback, and displaying the relevant appliance icon.

These changes provide a more comprehensive and interactive scheduling experience, laying the foundation for advanced features like sophisticated conflict detection and resolution.

## Test Plan

*   [ ] Run `npm run test` to ensure all unit tests pass.
*   [ ] Build and run the application using `docker-compose up --build -d`.
*   [ ] Access the application at `http://localhost:3917`.
*   [ ] **Test Individual Scheduling Page (`/schedule`)**:
    *   Verify `ApplianceSelector`, `ApartmentFilter`, and `ScheduleGrid` render correctly.
    *   Select an apartment (e.g., Stensvoll).
    *   Select an appliance (e.g., Oven).
    *   Click a time slot in the grid. Verify the oven icon appears for Stensvoll.
    *   Select a different apartment (e.g., Nowak) with the same appliance.
    *   Click a different time slot. Verify the oven icon appears for Nowak in that slot.
    *   Clicking an already scheduled slot for the selected apartment with the same appliance should clear it.
*   [ ] **Test Combined Schedule Page (`/schedule/combined`)**:
    *   Verify the `CombinedScheduleView` renders with mock data.
    *   Confirm that entries for different apartments in the same time slot are displayed and the slot itself is highlighted (e.g., Wednesday 18:00 in the mock data).
    *   Check that the color legend correctly displays colors for Stensvoll, Nowak, and Conflict.

🤖 Generated with [Claude Code](https://claude.ai/code)